### PR TITLE
fix: Configure PDM to use SCM versioning from git tags (#9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Issues = "https://github.com/ProteusLLP/proteusllp-optimisation-package/issues"
 Documentation = "https://proteusllp-optimisation-package.readthedocs.io/"
 
 [build-system]
-requires = ["pdm-backend"]
+requires = ["pdm-backend", "pdm-backend[scm]"]
 build-backend = "pdm.backend"
 
 # Static analysis tool configurations
@@ -87,6 +87,9 @@ skips = ["B101"]  # Skip assert_used test - asserts are normal in tests
 paths = ["optimizer"]
 min_confidence = 80
 exclude = ["__pypackages__/"]
+
+[tool.pdm.version]
+source = "scm"
 
 [tool.pdm.python]
 use_venv = true


### PR DESCRIPTION
- Add [tool.pdm.version] with source='scm' to enable git tag-based versioning
- Add pdm-backend[scm] to build requirements
- Fixes version showing as 0.0.0 instead of actual tag version