### PR TITLE
fix: Use absolute GitHub URL for POP logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div style="display: flex; align-items: center; gap: 15px;">
-  <img src="POP.svg" alt="POP Logo" width="80"/>
+  <img src="https://raw.githubusercontent.com/ProteusLLP/proteusllp-optimisation-package/main/POP.svg" alt="POP Logo" width="80"/>
   <div>
     <h1 style="margin: 0;">Proteus Optimisation Package (POP)</h1>
     <p style="margin: 5px 0 0 0;">


### PR DESCRIPTION
This pull request updates the image source for the POP logo in the `README.md` file to use an absolute URL instead of a relative path. This ensures the logo is always displayed correctly, regardless of where the file is viewed.

* Switched the `POP.svg` image source in `README.md` to an absolute URL pointing to the raw file in the GitHub repository, improving reliability of logo rendering.