### PR TITLE
fix: Use absolute GitHub URL for POP logo in README (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div style="display: flex; align-items: center; gap: 15px;">
-  <img src="POP.svg" alt="POP Logo" width="80"/>
+  <img src="https://raw.githubusercontent.com/ProteusLLP/proteusllp-optimisation-package/main/POP.svg" alt="POP Logo" width="80"/>
   <div>
     <h1 style="margin: 0;">Proteus Optimisation Package (POP)</h1>
     <p style="margin: 5px 0 0 0;">


### PR DESCRIPTION
This pull request makes a small update to the `README.md` file, changing the source of the POP logo image to use an absolute URL instead of a relative file path. This ensures the logo displays correctly regardless of where the README is viewed.